### PR TITLE
Don't fail on empty response lines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ export default async function* gen(reader: ReadableStreamDefaultReader): AsyncGe
     const parts = buf.split(matcher);
     buf = parts.pop();
     for (const i of parts) {
-      yield JSON.parse(i);
+      if (!i.match(/^\s*$/)) {
+        yield JSON.parse(i);
+      }
     }
 
     next = reader.read();

--- a/test/runner.js
+++ b/test/runner.js
@@ -32,6 +32,25 @@ const tests = [
     ],
   },
   {
+    pathname: '/api3',
+    handler: (res) => {
+      res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+      res.write(`{"a":1}\n`);
+      res.write(`\n`);
+      res.write(`{"b":2}\n`);
+      res.write(` \n`);
+      res.write(`{"c":3}\n`);
+      res.end();
+    },
+    expected: [
+      'pathname=/api3',
+      'done=false, value={"a":1}',
+      'done=false, value={"b":2}',
+      'done=false, value={"c":3}',
+      'done=true, value=undefined',
+    ],
+  },
+  {
     pathname: '/500',
     handler: (res) => {
       res.writeHead(500, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
We have an API that sometimes returns empty lines as part of the ND-JSON response. It's a bit weird, but as far as I can tell it's not necessarily invalid. Unfortunately `JSON.parse()` does not like empty strings, so just ignore those. Also ignore any lines only containing spaces as well. This is consistent in that `{"a":1}` and `  { "a": 1 }  ` currently result in the same behavior so it seems logical that `` (empty string) and ` ` should result in the same behavior, too.

Hope that this is acceptable, and thanks for taking a look!